### PR TITLE
Shortcuts and optimizations

### DIFF
--- a/ClassDumper.xcodeproj/project.pbxproj
+++ b/ClassDumper.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3A27E7552A26E8DC00B3537B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A27E7542A26E8DC00B3537B /* AppDelegate.swift */; };
 		3A27E7582A26EC9C00B3537B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A27E7572A26EC9C00B3537B /* Constants.swift */; };
 		3A27E75A2A26F20000B3537B /* MenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A27E7592A26F20000B3537B /* MenuCommands.swift */; };
+		3A27E75E2A283D3D00B3537B /* FirstAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A27E75D2A283D3D00B3537B /* FirstAppear.swift */; };
 		3AA564CF2A2310CD00EBD7FB /* ClassDumperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA564CE2A2310CD00EBD7FB /* ClassDumperApp.swift */; };
 		3AA564D12A2310CD00EBD7FB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA564D02A2310CD00EBD7FB /* ContentView.swift */; };
 		3AA564D32A2310CE00EBD7FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3AA564D22A2310CE00EBD7FB /* Assets.xcassets */; };
@@ -60,6 +61,7 @@
 		3A27E7542A26E8DC00B3537B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3A27E7572A26EC9C00B3537B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		3A27E7592A26F20000B3537B /* MenuCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCommands.swift; sourceTree = "<group>"; };
+		3A27E75D2A283D3D00B3537B /* FirstAppear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstAppear.swift; sourceTree = "<group>"; };
 		3AA564CB2A2310CD00EBD7FB /* Class Dumper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Class Dumper.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA564CE2A2310CD00EBD7FB /* ClassDumperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassDumperApp.swift; sourceTree = "<group>"; };
 		3AA564D02A2310CD00EBD7FB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				3A27E7572A26EC9C00B3537B /* Constants.swift */,
 				3AA565412A2575FB00EBD7FB /* AlertController.swift */,
 				3A27E7592A26F20000B3537B /* MenuCommands.swift */,
+				3A27E75D2A283D3D00B3537B /* FirstAppear.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -344,6 +347,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A27E7552A26E8DC00B3537B /* AppDelegate.swift in Sources */,
+				3A27E75E2A283D3D00B3537B /* FirstAppear.swift in Sources */,
 				3AA565492A25BD6F00EBD7FB /* String.swift in Sources */,
 				3A27E7532A26E86D00B3537B /* NSApplication.swift in Sources */,
 				3AA565422A2575FB00EBD7FB /* AlertController.swift in Sources */,

--- a/ClassDumper/ClassDumperApp.swift
+++ b/ClassDumper/ClassDumperApp.swift
@@ -19,7 +19,7 @@ struct ClassDumperApp: App {
                 })
         }
         .commands {
-             MenuCommands()
+            MenuCommands()
         }
 
         #if os(macOS)

--- a/ClassDumper/ContentView.swift
+++ b/ClassDumper/ContentView.swift
@@ -7,11 +7,12 @@ struct ContentView: View {
     @State private var searchText = ""
     @State private var selectedFolder = ""
     @State private var selectedFile = ""
+
     @State private var folderNames = [String]()
     @State private var fileNames = [String]()
     @State private var fileContents = ""
-    @State private var deletionEnabled = false
 
+    @State private var deletionEnabled = false
 
     var body: some View {
         NavigationSplitView {
@@ -94,7 +95,7 @@ extension ContentView {
             }
         }
     }
-    
+
     func MiddleListView() -> some View {
         Group {
             if noMatchesfound {
@@ -118,6 +119,7 @@ extension ContentView {
                     .onTapGesture {
                         onSecondarySelected(fileName: fileName)
                     }
+
                 }
             }
         }

--- a/ClassDumper/ContentView.swift
+++ b/ClassDumper/ContentView.swift
@@ -50,33 +50,31 @@ extension ContentView {
     // MARK: Views
 
     func SidebarListView() -> some View {
-        List {
-            ForEach(folderNames, id: \.self) { folderName in
-                HStack {
-                    Label {
-                        Text(folderName)
-                            .fontWeight(isSelectedFolder(folderName) ? .bold : .regular)
-                    } icon: {
-                        Image(systemName: "folder")
-                            .foregroundColor(.accentColor)
-                    }
-                    
-                    Spacer()
-                    
-                    if deletionEnabled {
-                        Button(action: {
-                            deleteDirectory(folder: folderName)
-                        }) {
-                            Image(systemName: "trash")
-                                .foregroundColor(.red)
-                        }
-                        .buttonStyle(BorderlessButtonStyle())
-                    }
+        List(folderNames, id: \.self) { folderName in
+            HStack {
+                Label {
+                    Text(folderName)
+                        .fontWeight(isSelectedFolder(folderName) ? .bold : .regular)
+                } icon: {
+                    Image(systemName: "folder")
+                        .foregroundColor(.accentColor)
                 }
-                .font(.subheadline)
-                .onTapGesture {
-                    onPrimarySelected(folderName: folderName)
+
+                Spacer()
+
+                if deletionEnabled {
+                    Button(action: {
+                        deleteDirectory(folder: folderName)
+                    }) {
+                        Image(systemName: "trash")
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(BorderlessButtonStyle())
                 }
+            }
+            .font(.subheadline)
+            .onTapGesture {
+                onPrimarySelected(folderName: folderName)
             }
         }
         .listStyle(SidebarListStyle())

--- a/ClassDumper/ContentView.swift
+++ b/ClassDumper/ContentView.swift
@@ -12,9 +12,6 @@ struct ContentView: View {
     @State private var fileContents = ""
     @State private var deletionEnabled = false
 
-    init() {
-        _folderNames = State(initialValue: getFiles(from: outputDirectory))
-    }
 
     var body: some View {
         NavigationSplitView {
@@ -31,6 +28,9 @@ struct ContentView: View {
                 onOpenInFinderPressed: openFileInFinder,
                 openInFinderDisabledCondition: selectedFile.isEmpty
             )
+        }
+        .onAppearOnce {
+            folderNames = getFiles(from: outputDirectory)
         }
         .onReceive(NotificationCenter.default.publisher(for: Notification.Name.newFilesAddedNotification)) { _ in
             folderNames = fetchFolders()

--- a/ClassDumper/ContentView.swift
+++ b/ClassDumper/ContentView.swift
@@ -147,6 +147,7 @@ extension ContentView {
                     Image(systemName: "info.circle")
                 }
                 .disabled(openInFinderDisabledCondition)
+                .keyboardShortcut("i", modifiers: [.command])
             }
         }
     }
@@ -260,6 +261,7 @@ struct ImportView: View {
         }) {
             Image(systemName: "plus")
         }
+        .keyboardShortcut("o", modifiers: [.command])
         .fileImporter(
             isPresented: $importing,
             allowedContentTypes: readableContentTypes

--- a/ClassDumper/Shared/FirstAppear.swift
+++ b/ClassDumper/Shared/FirstAppear.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+public extension View {
+    /// Performs the specified code block the first time the view this modifier is attached to appears.
+    /// - Parameter block: The callback to be performed only the first time the view appears.
+    func onAppearOnce(perform block: @escaping () -> Void) -> some View {
+        modifier(OnAppearOnce(callback: block))
+    }
+}
+
+private struct OnAppearOnce: ViewModifier {
+    @State private var performed = false
+    let callback: () -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                guard !performed else { return }
+                performed = true
+                callback()
+            }
+    }
+}


### PR DESCRIPTION
[Best viewed without whitespace changes](https://github.com/drewvolz/class-dumper/pull/2/files?diff=split&w=1)

* replace init method with onAppearOnce method
* add keyboard shortcuts
  * ⌘+i for opening the file in Finder
  * ⌘+o for opening the file browser
* replace foreach with list initializer