### PR TITLE
fix crash and update versions

### DIFF
--- a/ClassDumper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ClassDumper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ZeeZide/CodeEditor.git",
       "state" : {
-        "revision" : "180bde07b44dea839b32873bd8586ba146fa9106",
-        "version" : "1.2.2"
+        "revision" : "3a924589c957383693cae6336a29c3ead602ec96",
+        "version" : "1.2.4"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "e069e2732e3ee2b67bf89c1bda1937da0eaee7ef",
-        "version" : "6.24.2"
+        "revision" : "639fa9168d36931b36a79e60dc06b7d23852f1f4",
+        "version" : "6.27.0"
       }
     },
     {

--- a/ClassDumper/ClassDumperApp.swift
+++ b/ClassDumper/ClassDumperApp.swift
@@ -18,7 +18,7 @@ struct ClassDumperApp: App {
         }
         .commands {
             // overwritten and custom commands
-            MenuCommands()
+            MenuCommands(alertController: alertController)
             // provides font size
             TextFormattingCommands()
         }

--- a/ClassDumper/Shared/MenuCommands.swift
+++ b/ClassDumper/Shared/MenuCommands.swift
@@ -2,6 +2,11 @@ import SwiftUI
 
 struct MenuCommands: Commands {
     @SwiftUI.Environment(\.openURL) var openURL: OpenURLAction
+    @ObservedObject var alertController: AlertController
+
+    init(alertController: AlertController) {
+        self._alertController = ObservedObject(wrappedValue: alertController)
+    }
 
     var body: some Commands {
         CommandGroup(replacing: .appInfo) {
@@ -13,7 +18,7 @@ struct MenuCommands: Commands {
         }
 
         CommandGroup(after: .printItem) {
-            CreateFileButton()
+            CreateFileButton().environmentObject(alertController)
             FindSection()
         }
     }


### PR DESCRIPTION
Closes #20

- fix crash from file menu open action where alert controller was not passed to the MenuCommands
- update dependencies
  - grdb to 1.2.4
  - coeditor to 6.27.0