### PR TITLE
switch implementation from fileImporter to NSOpenPanel

### DIFF
--- a/ClassDumper/Views/DatabaseButtons.swift
+++ b/ClassDumper/Views/DatabaseButtons.swift
@@ -6,7 +6,6 @@ struct CreateFileButton: View {
     @Environment(\.fileRepository) private var fileRepository
     @EnvironmentObject var alertController: AlertController
 
-    @State private var importing = false
     private var titleKey: LocalizedStringKey
     
     init(_ titleKey: LocalizedStringKey = "Open…") {
@@ -41,7 +40,6 @@ struct CreateFileButton: View {
 
     var body: some View {
         Button {
-            importing = true
             openPanel()
         } label: {
             Label(titleKey, systemImage: "folder.badge.plus")

--- a/ClassDumper/Views/DatabaseButtons.swift
+++ b/ClassDumper/Views/DatabaseButtons.swift
@@ -21,7 +21,7 @@ struct CreateFileButton: View {
         return panel
     }()
 
-    func openPanel() {
+    private func openPanel() {
         switch panel.runModal() {
         case .OK:
             guard let url = panel.url else {

--- a/ClassDumper/Views/DatabaseButtons.swift
+++ b/ClassDumper/Views/DatabaseButtons.swift
@@ -47,10 +47,6 @@ struct CreateFileButton: View {
         .keyboardShortcut("o", modifiers: [.command])
     }
 }
-            }
-        }
-    }
-}
 
 extension CreateFileButton {
 

--- a/ClassDumper/Views/DatabaseButtons.swift
+++ b/ClassDumper/Views/DatabaseButtons.swift
@@ -13,22 +13,42 @@ struct CreateFileButton: View {
         self.titleKey = titleKey
     }
     
+    private var panel: NSOpenPanel = {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.application, .executable, .symbolicLink, .aliasFile]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.treatsFilePackagesAsDirectories = true
+        return panel
+    }()
+
+    func openPanel() {
+        switch panel.runModal() {
+        case .OK:
+            guard let url = panel.url else {
+                print("Unable to read file url path from NSOpenPanel.")
+                return
+            }
+            success(with: url)
+        case .cancel:
+            break // noop, need something on this line with breaks being implicit
+        case .abort, .stop:
+            print("Abort or stop result from NSOpenPanel. No filepath to pass.")
+        default:
+            print("Something went really wrong with NSOpenPanel. Unable to read file contents")
+        }
+    }
+
     var body: some View {
         Button {
             importing = true
+            openPanel()
         } label: {
             Label(titleKey, systemImage: "folder.badge.plus")
         }
         .keyboardShortcut("o", modifiers: [.command])
-        .fileImporter(
-            isPresented: $importing,
-            allowedContentTypes: [.application, .executable, .symbolicLink, .aliasFile]
-        ) { result in
-            switch result {
-            case .success(let file):
-                success(with: file)
-            case .failure(let error):
-                print("Unable to read file contents: \(error.localizedDescription)")
+    }
+}
             }
         }
     }

--- a/ClassDumperUITests/ImportFlow.swift
+++ b/ClassDumperUITests/ImportFlow.swift
@@ -148,7 +148,7 @@ struct ImportFlow: Screen {
     func openApp(named appName: String) -> Self {
         open(.filepicker)
 
-        app.sheets.firstMatch.outlineRows.staticTexts["Applications"].tap()
+        app.dialogs.firstMatch.outlineRows.staticTexts["Applications"].tap()
 
         // taking advantage of finder directing keyboard input towards the middle column
         app.typeText(appName)


### PR DESCRIPTION
Closes #22 

Switches from `fileImporter` to `NSOpenPanel` and allows for selecting binaries inside of a bundle which helps us from assuming we'd only want to classdump the main executable. Provides a greater customization of parameters from the browser as a bonus.

Thanks @tsilcher for the suggestion.